### PR TITLE
Enable configurable API host

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,9 @@
   <script>
     // ===== Config =====
     const DEFAULT_LANG = 'es-AR'; // preferencia local (Argentina) con fallback a es-ES
-    const WEBHOOK_URL = `http://localhost:5678/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat`;
+    const DEFAULT_HOST = 'http://localhost:5678';
+    const storedHost = localStorage.getItem('COS_N8N_HOST');
+    const WEBHOOK_URL = `${(storedHost || DEFAULT_HOST).replace(/\/$/, '')}/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat`;
     const sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
 
     // ===== Elements =====
@@ -343,6 +345,8 @@
     const micPermissionAlert = document.getElementById('micPermissionAlert');
     const enableMicBtn = document.getElementById('enableMicBtn');
     const skipMicBtn = document.getElementById('skipMicBtn');
+
+    if (storedHost) hostInput.value = storedHost;
 
     // ===== State =====
     let isListening = false, isProcessing = false, currentMode = 'voice';


### PR DESCRIPTION
## Summary
- Read API host from localStorage and default to localhost
- Prefill host override input when a host is stored

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/AgenteCOS/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_689b888d11dc832ca0006916e7fc9158