### PR TITLE
Remove special characters from speech output

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,7 +548,9 @@
 
         speechSynthesis.cancel();
 
-        const clean = (text||'').replace(/(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g,'');
+        const clean = (text||'')
+          .replace(/(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g,'')
+          .replace(/[^\p{L}\p{N}\s.,;:¡!¿?'"-]/gu,'');
 
         currentUtterance = new SpeechSynthesisUtterance(clean);
 


### PR DESCRIPTION
## Summary
- Strip asterisks and other special characters before speech synthesis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c934a5360832cbbc3bae51e71396d