### PR TITLE
Start inactivity timer when entering text mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@ let inactivitySeconds = 0;
 
 
     function showResponse(query, response){
-      if (currentMode==='voice') textModeBtn.click();
+      if (currentMode==='voice') switchToTextMode();
       const safeQuery = sanitize(query);
       const safeResponse = sanitize(response).replace(/\n/g,'<br>');
       const userDiv = document.createElement('div');
@@ -643,6 +643,24 @@ let inactivitySeconds = 0;
     function adjustTextareaHeight(){ messageInput.style.height='auto'; messageInput.style.height = Math.min(messageInput.scrollHeight, 140)+'px'; }
 
 
+    function switchToTextMode(){
+      console.log('Cambiando a modo texto');
+      currentMode='text';
+      textModeBtn.classList.add('active');
+      voiceModeBtn.classList.remove('active');
+      voiceInterface.classList.add('text-mode');
+      textInputArea.classList.add('show');
+      quickActions.classList.add('hide');
+      chatLog.classList.add('show');
+      isWakeWordActive = false;
+      stopWakeWordDetection();
+      messageInput.focus();
+      textModeBtn.setAttribute('aria-pressed','true');
+      voiceModeBtn.setAttribute('aria-pressed','false');
+      resetTextInactivityTimer();
+    }
+
+
     function switchToVoiceMode(){
       console.log('Cambiando a modo voz');
       currentMode='voice';
@@ -691,7 +709,7 @@ let inactivitySeconds = 0;
     voiceModeBtn.addEventListener('click', switchToVoiceMode);
 
 
-    textModeBtn.addEventListener('click', ()=>{ currentMode='text'; textModeBtn.classList.add('active'); voiceModeBtn.classList.remove('active'); voiceInterface.classList.add('text-mode'); textInputArea.classList.add('show'); quickActions.classList.add('hide'); chatLog.classList.add('show'); isWakeWordActive = false; stopWakeWordDetection(); messageInput.focus(); textModeBtn.setAttribute('aria-pressed','true'); voiceModeBtn.setAttribute('aria-pressed','false'); resetTextInactivityTimer(); });
+    textModeBtn.addEventListener('click', switchToTextMode);
 
 
 


### PR DESCRIPTION
## Summary
- Ensure text mode activations start the inactivity timer
- Centralize text mode logic in new `switchToTextMode` function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cad32d304832cbf6d5db0e68c5e1d