### PR TITLE
Fix session initialization and expose voice command

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,1 +1,5 @@
 export const WEBHOOK_URL = (typeof process !== 'undefined' && process.env && process.env.WEBHOOK_URL) ? process.env.WEBHOOK_URL : undefined;
+export const sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+export const DEFAULT_LANG = 'es-AR';
+export const DEFAULT_VOLUME = 0.9;
+export const TEXT_INACTIVITY_TIMEOUT_MS = 10000;

--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
     const DEFAULT_VOLUME = 0.9;
 
 
-    const sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
+    let sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
 
     const TEXT_INACTIVITY_TIMEOUT_MS = 10000;
 
@@ -308,7 +308,6 @@
     const skipMicBtn = document.getElementById('skipMicBtn');
 
     // ===== State =====
-let sessionId;
 let isListening = false, isProcessing = false, currentMode = 'voice';
 let recognition = null, wakeWordRecognition = null, isWakeWordActive = true;
 let currentUtterance = null;
@@ -675,7 +674,15 @@ let inactivitySeconds = 0;
 
 
 
-    function sendVoiceCommand(cmd){ if (currentMode==='voice') processVoiceInput(cmd); else { messageInput.value = cmd; sendTextMessage(); } }
+    function sendVoiceCommand(cmd){
+      if (currentMode === 'voice') {
+        processVoiceInput(cmd);
+      } else {
+        messageInput.value = cmd;
+        sendTextMessage();
+      }
+    }
+    window.sendVoiceCommand = sendVoiceCommand;
 
     function adjustTextareaHeight(){ messageInput.style.height='auto'; messageInput.style.height = Math.min(messageInput.scrollHeight, 140)+'px'; }
 


### PR DESCRIPTION
## Summary
- prevent duplicate `sessionId` declaration
- expose `sendVoiceCommand` for quick action buttons
- export common configuration values

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cc6162470832cbe24ac9ebb72b81c