### PR TITLE
Handle missing API URL

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,6 +1,9 @@
 import { WEBHOOK_URL, sessionId } from './config.js';
 
 export async function sendToAPI(message) {
+  if (!WEBHOOK_URL) {
+    throw new Error('WEBHOOK_URL is not defined');
+  }
   const payload = { chatInput: message, sessionId, timestamp: new Date().toISOString() };
   const res = await fetch(WEBHOOK_URL, {
     method: 'POST',

--- a/config.js
+++ b/config.js
@@ -1,4 +1,12 @@
-export const WEBHOOK_URL = (typeof process !== 'undefined' && process.env && process.env.WEBHOOK_URL) ? process.env.WEBHOOK_URL : undefined;
+const envUrl =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_WEBHOOK_URL) ||
+  (typeof process !== 'undefined' && process.env && process.env.WEBHOOK_URL) ||
+  '';
+
+export const WEBHOOK_URL = envUrl;
+if (!WEBHOOK_URL && typeof console !== 'undefined') {
+  console.warn('WEBHOOK_URL is not set; API requests will fail.');
+}
 export const sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2,8)}`;
 export const DEFAULT_LANG = 'es-AR';
 export const DEFAULT_VOLUME = 0.9;


### PR DESCRIPTION
## Summary
- warn when `WEBHOOK_URL` is missing and support both browser and Node environments
- throw explicit error if `sendToAPI` is called without a configured API URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689cc81fc3f4832ca2964b53160aad2c