### PR TITLE
Add JSON webhook server and start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "build": "vite build"
+    "build": "vite build",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,26 @@
+const http = require('http');
+
+const PORT = process.env.PORT || 5678;
+const PATH = '/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat';
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === PATH) {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ response: 'Consulta procesada correctamente.' }));
+    });
+  } else {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+module.exports = server;


### PR DESCRIPTION
## Summary
- provide simple Node webhook server returning JSON
- add npm start script for launching the server

## Testing
- `npm test`
- `curl -i http://localhost:5678/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat -H 'Content-Type: application/json' -d '{"chatInput":"hola"}'`


------
https://chatgpt.com/codex/tasks/task_b_689ccbd69c98832ca42b8bfe0e6ac60e