### PR TITLE
feat: make API path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ VITE_WEBHOOK_URL=http://localhost:5678/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb
 
 También puedes copiar `.env.example` a `.env` y ajustar el valor allí. Si no se define ninguna variable, se utilizará por defecto `http://localhost:5678/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat`.
 
+La ruta del endpoint también puede renombrarse mediante la variable `API_PATH` (o `VITE_API_PATH` en el cliente) para evitar rutas bloqueadas.
+
+```bash
+API_PATH=/mi-ruta-secreta/chat npm start
+```
+
 ## Pruebas
 
 1. Instala las dependencias:

--- a/config.js
+++ b/config.js
@@ -1,7 +1,14 @@
+const apiPath =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_PATH) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_PATH) ||
+  '/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat';
+
+export const API_PATH = apiPath;
+
 const envUrl =
   (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_WEBHOOK_URL) ||
   (typeof process !== 'undefined' && process.env && (process.env.VITE_WEBHOOK_URL || process.env.WEBHOOK_URL)) ||
-  'http://localhost:5678/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat';
+  `http://localhost:5678${API_PATH}`;
 
 export const WEBHOOK_URL = envUrl;
 if (!WEBHOOK_URL && typeof console !== 'undefined') {

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const http = require('http');
 
 const PORT = process.env.PORT || 5678;
-const PATH = '/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat';
+const PATH = process.env.API_PATH || '/webhook/2c8e40bc-d18d-458e-9d02-6ca7be1eb19c/chat';
 
 const server = http.createServer((req, res) => {
   if (req.method === 'POST' && req.url === PATH) {


### PR DESCRIPTION
## Summary
- allow overriding webhook endpoint path via new API_PATH environment variable
- use API_PATH in server POST route
- document API_PATH usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4b7413ed8832c9aab922ad1704f09